### PR TITLE
feat($member-entity): create member entity

### DIFF
--- a/src/main/java/com/support/oauth2postservice/domain/enumeration/LoginType.java
+++ b/src/main/java/com/support/oauth2postservice/domain/enumeration/LoginType.java
@@ -1,0 +1,6 @@
+package com.support.oauth2postservice.domain.enumeration;
+
+public enum LoginType {
+    LOCAL,
+    GOOGLE
+}

--- a/src/main/java/com/support/oauth2postservice/domain/enumeration/Role.java
+++ b/src/main/java/com/support/oauth2postservice/domain/enumeration/Role.java
@@ -1,0 +1,7 @@
+package com.support.oauth2postservice.domain.enumeration;
+
+public enum Role {
+    USER,
+    MANAGER,
+    ADMIN
+}

--- a/src/main/java/com/support/oauth2postservice/domain/enumeration/Status.java
+++ b/src/main/java/com/support/oauth2postservice/domain/enumeration/Status.java
@@ -1,0 +1,6 @@
+package com.support.oauth2postservice.domain.enumeration;
+
+public enum Status {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/com/support/oauth2postservice/domain/member/entity/Member.java
+++ b/src/main/java/com/support/oauth2postservice/domain/member/entity/Member.java
@@ -1,0 +1,50 @@
+package com.support.oauth2postservice.domain.member.entity;
+
+import com.support.oauth2postservice.domain.enumeration.LoginType;
+import com.support.oauth2postservice.domain.enumeration.Role;
+import com.support.oauth2postservice.domain.enumeration.Status;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"email"})})
+public class Member {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(length = 20)
+    private String name;
+
+    private String email;
+
+    private String password;
+
+    @Enumerated(value = EnumType.STRING)
+    private Role role;
+
+    @Enumerated(value = EnumType.STRING)
+    private Status status;
+
+    @Column(length = 10, name = "login_type")
+    @Enumerated(value = EnumType.STRING)
+    private LoginType loginType;
+
+    @Builder
+    public Member(String name, String email, String password, LoginType loginType) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.role = Role.USER;
+        this.status = Status.ACTIVE;
+        this.loginType = loginType != null ? loginType : LoginType.LOCAL;
+    }
+}

--- a/src/test/java/com/support/oauth2postservice/domain/member/entity/MemberTest.java
+++ b/src/test/java/com/support/oauth2postservice/domain/member/entity/MemberTest.java
@@ -1,0 +1,29 @@
+package com.support.oauth2postservice.domain.member.entity;
+
+import com.support.oauth2postservice.domain.enumeration.LoginType;
+import com.support.oauth2postservice.domain.enumeration.Role;
+import com.support.oauth2postservice.domain.enumeration.Status;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberTest {
+
+    @Test
+    @DisplayName("LoginType 기본 값 확인")
+    void defaultLoginType() {
+        Member member = Member.builder().build();
+
+        assertThat(member.getLoginType()).isEqualTo(LoginType.LOCAL);
+    }
+
+    @Test
+    @DisplayName("Role & Status 기본 값 확인")
+    void roleAndStatus() {
+        Member member = Member.builder().build();
+
+        assertThat(member.getRole()).isEqualTo(Role.USER);
+        assertThat(member.getStatus()).isEqualTo(Status.ACTIVE);
+    }
+}


### PR DESCRIPTION
Added fields to $member-entity
- id, name, email, password for user's information
- role, status, login type are enum. given its extendability, it was represented string
- set default value in specific constructor, also using builder pattern