### PR TITLE
refactor($jwt-config): refactor private key construction in $jwt-config

### DIFF
--- a/src/main/java/com/support/oauth2postservice/security/jwt/EllipticCurveFactory.java
+++ b/src/main/java/com/support/oauth2postservice/security/jwt/EllipticCurveFactory.java
@@ -15,21 +15,18 @@ import com.support.oauth2postservice.util.constant.Times;
 import com.support.oauth2postservice.util.constant.TokenConstants;
 import com.support.oauth2postservice.util.exception.ExceptionMessages;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Slf4j
 @Component
 public class EllipticCurveFactory extends TokenFactory {
-
-    @Value(value = "${jwt.secret}")
-    private String secret;
 
     private final OctetKeyPair privateJsonWebKey;
     private final OctetKeyPair publicJsonWebKey;
@@ -38,7 +35,7 @@ public class EllipticCurveFactory extends TokenFactory {
     public EllipticCurveFactory() throws JOSEException {
         privateJsonWebKey = new OctetKeyPairGenerator(Curve.Ed25519)
                 .keyUse(KeyUse.SIGNATURE)
-                .keyID(secret)
+                .keyID(UUID.randomUUID().toString())
                 .generate();
         ed25519Signer = new Ed25519Signer(privateJsonWebKey);
 

--- a/src/main/java/com/support/oauth2postservice/security/jwt/EllipticCurveVerifier.java
+++ b/src/main/java/com/support/oauth2postservice/security/jwt/EllipticCurveVerifier.java
@@ -19,10 +19,6 @@ public class EllipticCurveVerifier implements TokenVerifier {
 
     @Override
     public boolean isValid(String token) {
-        return verify(token);
-    }
-
-    private boolean verify(String token) {
         SignedJWT signedJWT = parse(token);
         try {
             return signedJWT.verify(ed25519Verifier);

--- a/src/test/java/com/support/oauth2postservice/etc/EllipticCurveKeyTest.java
+++ b/src/test/java/com/support/oauth2postservice/etc/EllipticCurveKeyTest.java
@@ -12,7 +12,10 @@ import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.codec.binary.Base64;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.security.InvalidAlgorithmParameterException;
@@ -24,30 +27,25 @@ import java.text.ParseException;
 import java.util.Date;
 import java.util.UUID;
 
+@DisplayName("타원 곡선 알고리즘 테스트")
 class EllipticCurveKeyTest {
 
-    @Test
-    @DisplayName("ECC private / public key 테스트")
-    void jwtTest() throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, JOSEException {
-        final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC");
-        keyPairGenerator.initialize(new ECGenParameterSpec("secp256r1"));
+    private OctetKeyPair publicJWK;
+    private OctetKeyPair privateJWK;
+    private SignedJWT signedJWT;
+    private Ed25519Verifier verifier;
+    private String serializedToken;
 
-        final KeyPair keyPair = keyPairGenerator.generateKeyPair();
-
-        System.out.println("ecKey.publicKey: " + Base64.encodeBase64String(keyPair.getPublic().getEncoded()));
-        System.out.println("ecKey.privateKey: " + Base64.encodeBase64String(keyPair.getPrivate().getEncoded()));
-    }
-
-    @Test
-    @DisplayName("ED25519 private / public key 테스트")
-    void ed25519Test() throws JOSEException, ParseException {
-        OctetKeyPair jwk = new OctetKeyPairGenerator(Curve.Ed25519)
+    @BeforeEach
+    @DisplayName("private & public key 생성")
+    void setUp() throws JOSEException {
+        privateJWK = new OctetKeyPairGenerator(Curve.Ed25519)
                 .keyUse(KeyUse.SIGNATURE)
-                .keyID("panda")
+                .keyID(UUID.randomUUID().toString())
                 .generate();
-        OctetKeyPair publicJWK = jwk.toPublicJWK();
 
-        Ed25519Signer signer = new Ed25519Signer(jwk);
+        Ed25519Signer signer = new Ed25519Signer(privateJWK);
+        publicJWK = privateJWK.toPublicJWK();
 
         JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
                 .subject("pandabear")
@@ -56,27 +54,80 @@ class EllipticCurveKeyTest {
                 .build();
 
         JWSHeader jwsHeader = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
-                .keyID(jwk.getKeyID())
+                .keyID(privateJWK.getKeyID())
                 .build();
 
-        SignedJWT signedJWT = new SignedJWT(jwsHeader, claimsSet);
-
+        signedJWT = new SignedJWT(jwsHeader, claimsSet);
         signedJWT.sign(signer);
-
-        String serializedToken = signedJWT.serialize();
-        System.out.println("serializedToken = " + serializedToken);
-
-        signedJWT = SignedJWT.parse(serializedToken);
-        System.out.println("signedJWT = " + signedJWT.getJWTClaimsSet());
-
-        Ed25519Verifier verifier = new Ed25519Verifier(publicJWK);
-        System.out.println("isVerified = " + signedJWT.verify(verifier));
+        verifier = new Ed25519Verifier(publicJWK);
     }
 
     @Test
-    @DisplayName("token-secret 생성")
-    void createTokenSecret() {
-        UUID tokenSecret = UUID.randomUUID();
-        System.out.println("tokenSecret = " + tokenSecret);
+    @DisplayName("비밀키에 'd' parameter (token-secret) 존재해야 한다")
+    void privateJWK() {
+        Assertions.assertThat(privateJWK.getD()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("공개키에 'd' parameter 존재하지 않아야 한다")
+    void publicJWK() {
+        Assertions.assertThat(publicJWK.getD()).isNull();
+    }
+
+    @Test
+    @DisplayName("서명된 토큰 직렬화")
+    void tokenSerialization() {
+        serializedToken = signedJWT.serialize();
+        Assertions.assertThat(serializedToken).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("서명된 토큰 역직렬화 후 검증")
+    void ed25519Test() throws ParseException, JOSEException {
+        serializedToken = signedJWT.serialize();
+        signedJWT = SignedJWT.parse(serializedToken);
+
+        boolean isVerified = signedJWT.verify(verifier);
+        Assertions.assertThat(isVerified).isTrue();
+    }
+
+    @Nested
+    @DisplayName("ECC secret & key 생성")
+    class OtherWayTest {
+
+        @Test
+        @DisplayName("token-secret 36 bytes 랜덤 생성")
+        void createTokenSecret() {
+            UUID tokenSecret = UUID.randomUUID();
+            Assertions.assertThat(tokenSecret.toString().length()).isEqualTo(36);
+        }
+
+        @Test
+        @DisplayName("KeyPairGenerator.getInstance() 생성 테스트")
+        void usingKeyPairGeneratorGetInstance() throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC");
+            keyPairGenerator.initialize(new ECGenParameterSpec("secp256r1"));
+            KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+            System.out.println("ecKey.publicKey     => " + Base64.encodeBase64String(keyPair.getPublic().getEncoded()));
+            System.out.println("ecKey.privateKey    => " + Base64.encodeBase64String(keyPair.getPrivate().getEncoded()));
+        }
     }
 }
+
+/*
+kty => key type
+d   => ECC private key
+crv => curve parameter
+kid => key id
+x/y => point (x, y)
+
+jwk = {
+  "kty":"OKP",
+  "d":"3shGAwPDVpz31nz_tC6IypS8Q3-AaAoeKp3o0_ziAA8",
+  "use":"sig",
+  "crv":"Ed25519",
+  "kid":"panda",
+  "x":"Gai7nhnN6ZyRpBRQRZp0nekfM70QiaG6-jfuZSkaSrw"
+}
+ */


### PR DESCRIPTION
- use uuid to generate key-id
- refactor verifier class, remove unnecessary indirection
- refactor test code for ec algorithm