### PR TITLE
refactor($security-config): remove pw-encoder dependency in domain

### DIFF
--- a/src/main/java/com/support/oauth2postservice/security/jwt/EllipticCurveFactory.java
+++ b/src/main/java/com/support/oauth2postservice/security/jwt/EllipticCurveFactory.java
@@ -24,6 +24,12 @@ import java.util.Date;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+/**
+ * 2022년 기준으로 ECC 암호화 알고리즘에서 가장 많이 사용되는 P-256 알고리즘의 경우<br/>
+ * ECC 알고리즘에서 보안을 위해 요구되는 요소 중 아래 요소들이 충족되지 않았다<br/>
+ * rigidity, ladders, completeness, indistinguishability <br/>
+ * 따라서 JWT 생성과 검증에는 P-256 대신 보안 요구 사항이 충족된 Ed25519 알고리즘을 사용한다<br/>
+ */
 @Slf4j
 @Component
 public class EllipticCurveFactory extends TokenFactory {

--- a/src/main/java/com/support/oauth2postservice/service/member/MemberService.java
+++ b/src/main/java/com/support/oauth2postservice/service/member/MemberService.java
@@ -28,7 +28,8 @@ public class MemberService {
   @Transactional
   public void join(MemberSignupRequest memberSignupRequest) {
     Member member = memberSignupRequest.toEntity();
-    member.encodePassword(passwordEncoder, memberSignupRequest.getPassword());
+    String encodedPassword = passwordEncoder.encode(member.getPassword());
+    member.putEncodedPassword(encodedPassword);
     memberRepository.save(member);
   }
 
@@ -40,7 +41,8 @@ public class MemberService {
     Member member = memberRepository.findActive(memberId)
         .orElseThrow(() -> new IllegalArgumentException(ExceptionMessages.MEMBER_NOT_FOUND));
 
-    member.encodePassword(passwordEncoder, memberEditRequest.getPassword());
+    String encodedPassword = passwordEncoder.encode(member.getPassword());
+    member.putEncodedPassword(encodedPassword);
     member.editInfo(memberEditRequest.getNickname(), memberEditRequest.getRole(), memberEditRequest.getStatus());
   }
 

--- a/src/main/java/com/support/oauth2postservice/util/constant/ColumnConstants.java
+++ b/src/main/java/com/support/oauth2postservice/util/constant/ColumnConstants.java
@@ -15,6 +15,7 @@ public class ColumnConstants {
     public static final int EMAIL = 320;
     public static final int NICKNAME = 20;
     public static final int PASSWORD_MIN = 4;
+    public static final int ENCODED_PASSWORD = 96;
   }
 
   public static class Name {

--- a/src/main/java/com/support/oauth2postservice/util/exception/ExceptionMessages.java
+++ b/src/main/java/com/support/oauth2postservice/util/exception/ExceptionMessages.java
@@ -5,6 +5,7 @@ public class ExceptionMessages {
   public static final String MEMBER_NOT_FOUND = "존재하지 않는 회원입니다";
   public static final String MEMBER_ALREADY_LEFT = "이미 탈퇴한 회원입니다";
   public static final String MEMBER_ACCESS_DENIED = "요청 권한이 없습니다";
+  public static final String PASSWORD_NOT_ENCODED = "요청 권한이 없습니다";
 
   public static final String POST_NOT_FOUND = "존재하지 않는 게시글입니다";
   public static final String POST_INCORRECT_DATE = "시작 시간이 종료 시간보다 늦을 수 없습니다";

--- a/src/test/java/com/support/oauth2postservice/domain/member/entity/MemberTest.java
+++ b/src/test/java/com/support/oauth2postservice/domain/member/entity/MemberTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,8 +43,10 @@ class MemberTest {
   @Test
   @DisplayName("비밀번호 암호화 성공")
   void encodePassword() {
-    PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-    user.encodePassword(passwordEncoder, "1234");
+    PasswordEncoder passwordEncoder = new Argon2PasswordEncoder();
+    String rawPassword = "1234";
+    String encodedPassword = passwordEncoder.encode(rawPassword);
+    user.putEncodedPassword(encodedPassword);
 
     boolean isMatched = passwordEncoder.matches("1234", user.getPassword());
     assertThat(isMatched).isEqualTo(true);

--- a/src/test/java/com/support/oauth2postservice/security/config/SecurityConfigTest.java
+++ b/src/test/java/com/support/oauth2postservice/security/config/SecurityConfigTest.java
@@ -1,0 +1,55 @@
+package com.support.oauth2postservice.security.config;
+
+import com.support.oauth2postservice.util.constant.ColumnConstants;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecurityConfigTest {
+
+  @Test
+  @DisplayName("기본 Argon2id Encoding 시 입력값과 상관 없이 결과 값 96 byte")
+  void passwordEncoding() {
+    Argon2PasswordEncoder argon2PasswordEncoder = new Argon2PasswordEncoder();
+    String p = "panda";
+
+    String encode1 = argon2PasswordEncoder.encode(p);
+    String encode2 = argon2PasswordEncoder.encode(p + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p);
+    String encode3 = argon2PasswordEncoder.encode(p + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p
+        + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p
+        + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p
+        + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p);
+    String encode4 = argon2PasswordEncoder.encode(p + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p
+        + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p
+        + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p
+        + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p
+        + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p
+        + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p
+        + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p
+        + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p + p);
+
+    assertThat(encode1.length()).isEqualTo(ColumnConstants.Length.ENCODED_PASSWORD);
+    assertThat(encode2.length()).isEqualTo(ColumnConstants.Length.ENCODED_PASSWORD);
+    assertThat(encode3.length()).isEqualTo(ColumnConstants.Length.ENCODED_PASSWORD);
+    assertThat(encode4.length()).isEqualTo(ColumnConstants.Length.ENCODED_PASSWORD);
+  }
+
+  @Test
+  @DisplayName("커스텀 Argon2 Encoding 시 결과 값 달라질 수 있다")
+  void customArgonPasswordEncoder() {
+    Argon2PasswordEncoder argon2PasswordEncoder = new Argon2PasswordEncoder(32, 32, 2, 1 << 13, 3);
+
+    String b = "bear";
+
+    String encode1 = argon2PasswordEncoder.encode(b + b + b + b + b + b + b + b + b + b + b + b + b + b + b + b);
+    String encode2 = argon2PasswordEncoder.encode(b + b + b + b + b + b + b + b + b + b + b + b + b + b + b + b
+        + b + b + b + b + b + b + b + b + b + b + b + b + b + b + b + b
+        + b + b + b + b + b + b + b + b + b + b + b + b + b + b + b + b
+        + b + b + b + b + b + b + b + b + b + b + b + b + b + b + b + b);
+
+    assertThat(encode1.length()).isEqualTo(117);
+    assertThat(encode2.length()).isEqualTo(117);
+  }
+}

--- a/src/test/java/com/support/oauth2postservice/service/member/MemberServiceTest.java
+++ b/src/test/java/com/support/oauth2postservice/service/member/MemberServiceTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.orm.jpa.JpaObjectRetrievalFailureException;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.Optional;
@@ -21,13 +23,14 @@ class MemberServiceTest extends ServiceTest {
 
   private Member user;
   private MemberSignupRequest userRequest;
+  private final PasswordEncoder passwordEncoder = new Argon2PasswordEncoder();
 
   @BeforeEach
   void setUp() {
-    memberService = new MemberService(memberRepository, passwordEncoder);
-
     user = MemberTestHelper.createUser();
+    user.putEncodedPassword(passwordEncoder.encode(user.getPassword()));
     userRequest = MemberTestHelper.createUserRequest();
+    memberService = new MemberService(memberRepository, passwordEncoder);
   }
 
   @Test


### PR DESCRIPTION

- add password column length constraint
- add comment on argon2-encoding & jwt ecc algorithm
- refactor service layer test code for member, because of password constraint