### PR TITLE
feat($aop-setting): add error-logging by $aop-setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ ext {
 
 dependencies {
 	implementation 'com.lmax:disruptor:3.4.4'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
@@ -58,6 +59,7 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
 
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/support/oauth2postservice/aop/LogAspect.java
+++ b/src/main/java/com/support/oauth2postservice/aop/LogAspect.java
@@ -1,0 +1,34 @@
+package com.support.oauth2postservice.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Aspect
+@Component
+public class LogAspect {
+
+  @AfterReturning(value = "bean(*ExceptionHandler)")
+  public void logForException(JoinPoint joinPoint) {
+    log.info("[SUPPORT-ERROR] :: method     -> {}", joinPoint.getSignature().toShortString());
+    log.info("[SUPPORT-ERROR] :: arguments  -> {}", joinPoint.getArgs());
+
+    CompletableFuture.runAsync(
+        () -> Arrays.stream(joinPoint.getArgs())
+            .filter(arg -> arg instanceof Exception)
+            .forEach(arg -> log.error("[SUPPORT-ERROR] :: exception {}", (Exception) arg))
+    );
+
+    Arrays.stream(joinPoint.getArgs())
+        .filter(arg -> arg instanceof Exception)
+        .flatMap(arg -> Arrays.stream(((Exception) arg).getStackTrace()))
+        .limit(1)
+        .forEach(stackTraceElement -> log.info("[SUPPORT-ERROR] :: exception  -> {}", stackTraceElement));
+  }
+}

--- a/src/main/java/com/support/oauth2postservice/aop/annotations/LogForException.java
+++ b/src/main/java/com/support/oauth2postservice/aop/annotations/LogForException.java
@@ -1,0 +1,11 @@
+package com.support.oauth2postservice.aop.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = {ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogForException {
+}

--- a/src/main/java/com/support/oauth2postservice/controller/ExceptionResponse.java
+++ b/src/main/java/com/support/oauth2postservice/controller/ExceptionResponse.java
@@ -1,0 +1,18 @@
+package com.support.oauth2postservice.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class ExceptionResponse {
+
+  private final String exception;
+  private final String message;
+
+  public static ExceptionResponse of(String exception, String message) {
+    return new ExceptionResponse(exception, message);
+  }
+}

--- a/src/main/java/com/support/oauth2postservice/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/support/oauth2postservice/controller/GlobalExceptionHandler.java
@@ -1,0 +1,81 @@
+package com.support.oauth2postservice.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.support.oauth2postservice.aop.annotations.LogForException;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.persistence.EntityNotFoundException;
+import javax.validation.ConstraintViolationException;
+
+@LogForException
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+  private final ObjectMapper objectMapper;
+
+  private static String getExceptionClass(Exception e) {
+    return e != null ? e.getClass().getName() : "";
+  }
+
+  @ExceptionHandler(value = NullPointerException.class)
+  public ResponseEntity<ExceptionResponse> nullPointerExceptionHandler(Exception e) {
+    return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).body(ExceptionResponse.of(getExceptionClass(e), e.getMessage()));
+  }
+
+  @ExceptionHandler(value = IllegalArgumentException.class)
+  public ResponseEntity<ExceptionResponse> illegalArgumentExceptionHandler(Exception e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ExceptionResponse.of(getExceptionClass(e), e.getMessage()));
+  }
+
+  @ExceptionHandler(value = IllegalStateException.class)
+  public ResponseEntity<ExceptionResponse> illegalStateExceptionHandler(Exception e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ExceptionResponse.of(getExceptionClass(e), e.getMessage()));
+  }
+
+  @ExceptionHandler(value = AuthenticationException.class)
+  public ResponseEntity<ExceptionResponse> authenticationExceptionHandler(Exception e) {
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ExceptionResponse.of(getExceptionClass(e), e.getMessage()));
+  }
+
+  @ExceptionHandler(value = EntityNotFoundException.class)
+  public ResponseEntity<ExceptionResponse> entityNotFoundExceptionHandler(Exception e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ExceptionResponse.of(getExceptionClass(e), e.getMessage()));
+  }
+
+  @ExceptionHandler(value = UsernameNotFoundException.class)
+  public ResponseEntity<ExceptionResponse> usernameNotFoundExceptionHandler(Exception e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ExceptionResponse.of(getExceptionClass(e), e.getMessage()));
+  }
+
+  @ExceptionHandler(value = JsonProcessingException.class)
+  public ResponseEntity<ExceptionResponse> jsonProcessingExceptionHandler(Exception e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ExceptionResponse.of(getExceptionClass(e), e.getMessage()));
+  }
+
+  @ExceptionHandler(value = AccessDeniedException.class)
+  public ResponseEntity<ExceptionResponse> accessDeniedExceptionHandler(Exception e) {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ExceptionResponse.of(getExceptionClass(e), e.getMessage()));
+  }
+
+  @ExceptionHandler(value = ConstraintViolationException.class)
+  public ResponseEntity<ExceptionResponse> constraintViolationExceptionHandler(ConstraintViolationException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ExceptionResponse.of(getExceptionClass(e), e.getMessage()));
+  }
+
+  @SneakyThrows(value = JsonProcessingException.class)
+  @ExceptionHandler(value = MethodArgumentNotValidException.class)
+  public ResponseEntity<String> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(objectMapper.writeValueAsString(e.getBindingResult()));
+  }
+}

--- a/src/main/java/com/support/oauth2postservice/controller/TestController.java
+++ b/src/main/java/com/support/oauth2postservice/controller/TestController.java
@@ -25,4 +25,14 @@ public class TestController {
   public String home() {
     return "home";
   }
+
+  @GetMapping("/error-please")
+  public void errorBomb() {
+    throw new IllegalArgumentException("YAHOO ~~~~~");
+  }
+
+  @GetMapping("/error-please2")
+  public void errorBomb2() {
+    throw new IllegalStateException("HOORAY ~~~~~");
+  }
 }

--- a/src/main/java/com/support/oauth2postservice/domain/member/entity/Member.java
+++ b/src/main/java/com/support/oauth2postservice/domain/member/entity/Member.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 
 /**
  * Member Entity 중 AuthProvider 란 인증 제공자를 의미한다<br/>
- * 애플리케이션 자체 로그인의 경우 LOCAL, 그 외 각 벤더사의 이름을 나타낸다<br/><br/>
+ * 애플리케이션 자체 로그인의 경우 LOCAL, 그 외 각 벤더의 이름을 나타낸다<br/><br/>
  * InitialAuthProvider - 신규 유입 통계를 확인하기 위해 초기 진입점 표현<br/>
  * LatestAuthProvider - 로그인 방식이 달라질 때 현재 인증 제공자 표현<br/>
  * 각각의 처리를 담당하는 CustomUserDetailsService, CustomOAuth2USerService 에서 변경 된다<br/>

--- a/src/main/java/com/support/oauth2postservice/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/support/oauth2postservice/security/service/CustomOAuth2UserService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityListeners;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -38,11 +39,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
   }
 
   private Member getMember(String registrationId, OAuth2Attributes attributes) {
-    memberRepository.findActiveByEmail(attributes.getEmail())
+    Optional<Member> probableMember = memberRepository.findActiveByEmail(attributes.getEmail());
+    probableMember
         .ifPresent(member -> member.synchronizeLatestAuthProvider(AuthProvider.valueOf(registrationId.toUpperCase())));
 
-    return memberRepository.findActiveByEmail(attributes.getEmail())
-        .orElseGet(() -> getNewlyRegistered(registrationId, attributes));
+    return probableMember.orElseGet(() -> getNewlyRegistered(registrationId, attributes));
   }
 
   private Member getNewlyRegistered(String registrationId, OAuth2Attributes oAuth2Attributes) {

--- a/src/main/java/com/support/oauth2postservice/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/support/oauth2postservice/security/service/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package com.support.oauth2postservice.security.service;
 
 import com.support.oauth2postservice.domain.enumeration.AuthProvider;
+import com.support.oauth2postservice.domain.member.entity.Member;
 import com.support.oauth2postservice.domain.member.repository.MemberRepository;
 import com.support.oauth2postservice.security.dto.UserPrincipal;
 import com.support.oauth2postservice.util.exception.ExceptionMessages;
@@ -11,6 +12,8 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
@@ -20,10 +23,10 @@ public class CustomUserDetailsService implements UserDetailsService {
   @Override
   @Transactional
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-    memberRepository.findActiveByEmail(username)
-        .ifPresent(member -> member.synchronizeLatestAuthProvider(AuthProvider.LOCAL));
+    Optional<Member> probableMember = memberRepository.findActiveByEmail(username);
+    probableMember.ifPresent(member -> member.synchronizeLatestAuthProvider(AuthProvider.LOCAL));
 
-    return memberRepository.findActiveByEmail(username)
+    return probableMember
         .map(UserPrincipal::from)
         .orElseThrow(() -> new UsernameNotFoundException(ExceptionMessages.MEMBER_NOT_FOUND));
   }

--- a/src/test/java/com/support/oauth2postservice/util/security/service/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/support/oauth2postservice/util/security/service/CustomUserDetailsServiceTest.java
@@ -32,7 +32,7 @@ class CustomUserDetailsServiceTest extends ServiceTest {
     UserDetails userDetails = customUserDetailsService.loadUserByUsername(MemberTestHelper.USER_EMAIL);
 
     assertThat(userDetails.getUsername()).isEqualTo(MemberTestHelper.USER_EMAIL);
-    verify(memberRepository, times(2)).findActiveByEmail(MemberTestHelper.USER_EMAIL);
+    verify(memberRepository, times(1)).findActiveByEmail(MemberTestHelper.USER_EMAIL);
   }
 
   @Test


### PR DESCRIPTION
- store log to file
- classify log into operation, error and query
- refactor custom user-details & oauth2-user service
- add global-exception-handler to handle communal exception response