### PR TITLE
chore($querydsl-utils): add suppress-warnings annotation

### DIFF
--- a/src/main/java/com/support/oauth2postservice/util/QueryDslUtils.java
+++ b/src/main/java/com/support/oauth2postservice/util/QueryDslUtils.java
@@ -24,6 +24,7 @@ public class QueryDslUtils {
     }
   }
 
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public static OrderSpecifier<?>[] getSortedColumn(Sort sorts, Path<?> parent) {
     return sorts.stream()
         .map(sort -> {


### PR DESCRIPTION
- add suppress-warnings to getSortedColumn method in $querydsl-utils
- result of tradeoff between convenience and type-safety