### PR TITLE
feat($cache-service): add cache-service to save token temporarily

### DIFF
--- a/src/main/java/com/support/oauth2postservice/config/EmbeddedRedisConfig.java
+++ b/src/main/java/com/support/oauth2postservice/config/EmbeddedRedisConfig.java
@@ -16,7 +16,7 @@ import java.io.InputStreamReader;
 
 @Slf4j
 @Configuration
-@Profile({"test", "local"})
+@Profile("test")
 @RequiredArgsConstructor
 @EnableConfigurationProperties(RedisProperties.class)
 public class EmbeddedRedisConfig {
@@ -70,7 +70,7 @@ public class EmbeddedRedisConfig {
       while ((line = input.readLine()) != null)
         pidInfo.append(line);
     } catch (Exception e) {
-      log.info("[ERROR] embedded-redis not working");
+      log.info("[FAILED] EMBEDDED-REDIS NOT WORKING");
     }
 
     return !StringUtils.isEmpty(pidInfo.toString());

--- a/src/main/java/com/support/oauth2postservice/controller/view/MemberViewController.java
+++ b/src/main/java/com/support/oauth2postservice/controller/view/MemberViewController.java
@@ -5,9 +5,11 @@ import com.support.oauth2postservice.service.dto.request.MemberEditRequest;
 import com.support.oauth2postservice.service.dto.request.MemberSearchRequest;
 import com.support.oauth2postservice.service.dto.response.MemberReadResponse;
 import com.support.oauth2postservice.util.SecurityUtils;
+import com.support.oauth2postservice.util.constant.SpELConstants;
 import com.support.oauth2postservice.util.constant.UriConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,6 +25,7 @@ public class MemberViewController {
   private final MemberService memberService;
 
   @GetMapping(UriConstants.Mapping.MEMBERS)
+  @PreAuthorize(SpELConstants.MANAGER_GOE_ALLOWED)
   public String getMembers(@Valid MemberSearchRequest memberSearchRequest, Model model) {
     Page<MemberReadResponse> memberReadResponses = memberService.searchByCondition(memberSearchRequest);
 

--- a/src/main/java/com/support/oauth2postservice/security/config/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/support/oauth2postservice/security/config/OAuth2AuthenticationSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.support.oauth2postservice.security.config;
 
+import com.support.oauth2postservice.domain.enumeration.Role;
 import com.support.oauth2postservice.security.dto.OAuth2UserPrincipal;
 import com.support.oauth2postservice.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.support.oauth2postservice.security.oauth2.OAuth2TokenResponse;
@@ -9,12 +10,15 @@ import com.support.oauth2postservice.util.constant.UriConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -24,7 +28,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
   private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
   @Override
-  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
     httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
 
     SecurityUtils.setAuthentication(authentication);
@@ -37,6 +41,15 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         .build();
 
     CookieUtils.setOAuth2TokenToBrowser(response, oAuth2TokenResponse);
-    response.sendRedirect(UriConstants.Mapping.ROOT);
+
+    String authority = principal.getAuthorities()
+        .stream()
+        .map(GrantedAuthority::getAuthority)
+        .collect(Collectors.joining(""));
+
+    if (Role.USER.getKey().equalsIgnoreCase(authority))
+      response.sendRedirect(UriConstants.Mapping.ROOT);
+    else
+      request.getRequestDispatcher(UriConstants.Mapping.MEMBERS).forward(request, response);
   }
 }

--- a/src/main/java/com/support/oauth2postservice/security/dto/OAuth2UserPrincipal.java
+++ b/src/main/java/com/support/oauth2postservice/security/dto/OAuth2UserPrincipal.java
@@ -2,14 +2,15 @@ package com.support.oauth2postservice.security.dto;
 
 import com.support.oauth2postservice.domain.entity.Member;
 import com.support.oauth2postservice.domain.enumeration.Status;
+import com.support.oauth2postservice.util.constant.TokenConstants;
 import com.support.oauth2postservice.util.exception.ExceptionMessages;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.OAuth2Token;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
@@ -20,7 +21,6 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Getter
 @ToString
@@ -41,10 +41,10 @@ public class OAuth2UserPrincipal implements OAuth2User, OidcUser {
         member.getId(),
         member.getEmail(),
         member.getStatus(),
-        Jwt.withTokenValue("").build(),
-        OidcIdToken.withTokenValue("").build(),
-        new ConcurrentHashMap<>(),
-        new ConcurrentHashMap<>(),
+        Jwt.withTokenValue("NOT_VALID").issuer(TokenConstants.OAUTH2_GOOGLE_TOKEN_ISSUER).build(),
+        OidcIdToken.withTokenValue("NOT_VALID").issuer(TokenConstants.OAUTH2_GOOGLE_TOKEN_ISSUER).build(),
+        Collections.emptyMap(),
+        Collections.emptyMap(),
         Collections.singletonList(new SimpleGrantedAuthority(member.getRole().getKey()))
     );
   }
@@ -68,7 +68,7 @@ public class OAuth2UserPrincipal implements OAuth2User, OidcUser {
         member.getStatus(),
         oAuth2Token,
         OidcIdToken.withTokenValue("").build(),
-        new ConcurrentHashMap<>(),
+        Collections.emptyMap(),
         oAuth2User.getAttributes(),
         Collections.singletonList(new SimpleGrantedAuthority(member.getRole().getKey()))
     );
@@ -88,21 +88,21 @@ public class OAuth2UserPrincipal implements OAuth2User, OidcUser {
   }
 
   public Authentication toAuthentication() {
-    return new OAuth2AuthenticationToken(
+    return new UsernamePasswordAuthenticationToken(
         this,
-        this.authorities,
-        this.attributes.getOrDefault("registrationId", "google").toString()
+        "",
+        this.authorities
     );
   }
 
   @Override
   public Map<String, Object> getAttributes() {
-    return attributes;
+    return Collections.unmodifiableMap(attributes);
   }
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    return authorities;
+    return Collections.unmodifiableCollection(authorities);
   }
 
   @Override
@@ -112,7 +112,7 @@ public class OAuth2UserPrincipal implements OAuth2User, OidcUser {
 
   @Override
   public Map<String, Object> getClaims() {
-    return claims;
+    return Collections.unmodifiableMap(claims);
   }
 
   @Override

--- a/src/main/java/com/support/oauth2postservice/security/jwt/EllipticCurveFactory.java
+++ b/src/main/java/com/support/oauth2postservice/security/jwt/EllipticCurveFactory.java
@@ -63,10 +63,11 @@ public class EllipticCurveFactory extends TokenFactory {
 
     String authorities = authentication.getAuthorities().stream()
         .map(GrantedAuthority::getAuthority)
-        .collect(Collectors.joining(","));
+        .collect(Collectors.joining(""));
 
     JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
         .subject(getIdFromAuthentication(authentication))
+        .issuer(TokenConstants.LOCAL_TOKEN_ISSUER)
         .claim(TokenConstants.AUTHORITIES, authorities)
         .claim(TokenConstants.TOKEN_TYPE, TokenConstants.ACCESS_TOKEN)
         .expirationTime(new Date(currentTime + Times.ACCESS_TOKEN_EXPIRATION_MILLIS.getValue()))
@@ -81,10 +82,10 @@ public class EllipticCurveFactory extends TokenFactory {
 
   private String getIdFromAuthentication(Authentication authentication) {
     Object principal = authentication.getPrincipal();
-    if (principal instanceof UserPrincipal) {
-      return ((UserPrincipal) principal).getId();
-    }
-    return null;
+    if (!(principal instanceof UserPrincipal))
+      return "";
+
+    return ((UserPrincipal) principal).getId();
   }
 
   @Override
@@ -93,6 +94,7 @@ public class EllipticCurveFactory extends TokenFactory {
 
     JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
         .subject(authentication.getName())
+        .issuer(TokenConstants.LOCAL_TOKEN_ISSUER)
         .claim(TokenConstants.TOKEN_TYPE, TokenConstants.REFRESH_TOKEN)
         .expirationTime(new Date(currentTime + Times.REFRESH_TOKEN_EXPIRATION_MILLIS.getValue()))
         .build();

--- a/src/main/java/com/support/oauth2postservice/security/jwt/GoogleOidcVerifier.java
+++ b/src/main/java/com/support/oauth2postservice/security/jwt/GoogleOidcVerifier.java
@@ -10,9 +10,12 @@ import com.support.oauth2postservice.util.constant.TokenConstants;
 import com.support.oauth2postservice.util.exception.ExceptionMessages;
 import com.support.oauth2postservice.util.wrapper.WebClientWrappable;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class GoogleOidcVerifier implements OAuth2TokenVerifier {
@@ -41,7 +44,14 @@ public class GoogleOidcVerifier implements OAuth2TokenVerifier {
     try {
       return JWT.decode(idToken);
     } catch (JWTDecodeException e) {
+      log.info("[FAILED] :: OAUTH2 JWT PARSING FAILED => {}", e.getMessage());
       throw new TokenException(ExceptionMessages.Token.WRONG_FORMAT, e);
     }
+  }
+
+  @Override
+  public boolean isGoogleToken(String idToken) {
+    DecodedJWT decodedJWT = parse(idToken);
+    return StringUtils.equalsIgnoreCase(TokenConstants.OAUTH2_GOOGLE_TOKEN_ISSUER, decodedJWT.getIssuer());
   }
 }

--- a/src/main/java/com/support/oauth2postservice/security/jwt/OAuth2TokenVerifier.java
+++ b/src/main/java/com/support/oauth2postservice/security/jwt/OAuth2TokenVerifier.java
@@ -2,4 +2,10 @@ package com.support.oauth2postservice.security.jwt;
 
 public interface OAuth2TokenVerifier extends TokenVerifier {
 
+  @Override
+  default boolean isLocalToken(String accessToken) {
+    return false;
+  }
+
+  boolean isGoogleToken(String idToken);
 }

--- a/src/main/java/com/support/oauth2postservice/security/jwt/TokenVerifier.java
+++ b/src/main/java/com/support/oauth2postservice/security/jwt/TokenVerifier.java
@@ -6,5 +6,7 @@ public interface TokenVerifier {
 
   boolean isValid(String token);
 
+  boolean isLocalToken(String accessToken);
+
   Authentication getAuthentication(String token);
 }

--- a/src/main/java/com/support/oauth2postservice/service/CacheService.java
+++ b/src/main/java/com/support/oauth2postservice/service/CacheService.java
@@ -1,0 +1,18 @@
+package com.support.oauth2postservice.service;
+
+public interface CacheService {
+
+  String getData(String key);
+
+  int getDataAsInt(String key);
+
+  void setData(String key, Object value);
+
+  void setDataAndExpiration(String key, Object value, long duration);
+
+  void deleteData(String key);
+
+  void increment(String key);
+
+  <T> T getObjectData(String key, Class<T> t);
+}

--- a/src/main/java/com/support/oauth2postservice/service/RedisCacheService.java
+++ b/src/main/java/com/support/oauth2postservice/service/RedisCacheService.java
@@ -1,0 +1,69 @@
+package com.support.oauth2postservice.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Objects;
+
+@Slf4j
+@Service
+public class RedisCacheService implements CacheService {
+
+  private final ObjectMapper objectMapper;
+  private final StringRedisTemplate stringRedisTemplate;
+  private final ValueOperations<String, String> stringValueOperations;
+
+  public RedisCacheService(ObjectMapper objectMapper, StringRedisTemplate stringRedisTemplate) {
+    this.objectMapper = objectMapper;
+    this.stringRedisTemplate = stringRedisTemplate;
+    this.stringValueOperations = stringRedisTemplate.opsForValue();
+  }
+
+  @Override
+  public String getData(String key) {
+    return stringValueOperations.get(key);
+  }
+
+  @Override
+  public int getDataAsInt(String key) {
+    return Integer.parseInt(Objects.requireNonNull(stringValueOperations.get(key)));
+  }
+
+  @Override
+  public void setData(String key, Object value) {
+    stringValueOperations.set(key, String.valueOf(value));
+  }
+
+  @Override
+  public void setDataAndExpiration(String key, Object value, long duration) {
+    Duration expireDuration = Duration.ofSeconds(duration);
+    stringValueOperations.set(key, String.valueOf(value), expireDuration);
+  }
+
+  @Override
+  public void deleteData(String key) {
+    stringRedisTemplate.delete(key);
+  }
+
+  @Override
+  public void increment(String key) {
+    stringValueOperations.increment(key);
+  }
+
+  @Override
+  public <T> T getObjectData(String key, Class<T> t) {
+    try {
+      return objectMapper.readValue(stringValueOperations.get(key), new TypeReference<T>() {
+      });
+    } catch (JsonProcessingException e) {
+      log.info("[ERROR] :: INVALID OR NON-EXIST CACHE KEY => {} ", key);
+      return null;
+    }
+  }
+}

--- a/src/main/java/com/support/oauth2postservice/util/constant/TokenConstants.java
+++ b/src/main/java/com/support/oauth2postservice/util/constant/TokenConstants.java
@@ -7,9 +7,10 @@ import lombok.NoArgsConstructor;
 public class TokenConstants {
 
   public static final String BEARER_TYPE = "Bearer ";
-  public static final String LOCAL_ACCESS_TOKEN_PREFIX = "eyJraW";
-  public static final String OAUTH2_ACCESS_TOKEN_PREFIX = "ya29";
   public static final String AUTHORIZATION_HEADER = "Authorization";
+
+  public static final String LOCAL_TOKEN_ISSUER = "https://accounts.support.com";
+  public static final String OAUTH2_GOOGLE_TOKEN_ISSUER = "https://accounts.google.com";
 
   public static final String CODE = "code";
   public static final String ERROR = "error";

--- a/src/test/java/com/support/oauth2postservice/security/jwt/GoogleOidcVerifierTest.java
+++ b/src/test/java/com/support/oauth2postservice/security/jwt/GoogleOidcVerifierTest.java
@@ -2,33 +2,44 @@ package com.support.oauth2postservice.security.jwt;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import org.assertj.core.api.Assertions;
+import com.support.oauth2postservice.config.JpaTest;
+import com.support.oauth2postservice.helper.MockWebClientWrapper;
+import com.support.oauth2postservice.util.constant.TokenConstants;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 
 import java.util.Base64;
-import java.util.Date;
 
-class GoogleOidcVerifierTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DataJpaTest
+class GoogleOidcVerifierTest extends JpaTest {
 
   private final String idToken = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjNkZDZjYTJhODFkYzJmZWE4YzM2NDI0MzFlN2UyOTZkMmQ3NWI0NDYiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiI0NDc2Njg1MDI2OTUtaWxkMXJtNXNiaXZiOWlua3J2dWlkZDg5YWdwbWMyNmcuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI0NDc2Njg1MDI2OTUtaWxkMXJtNXNiaXZiOWlua3J2dWlkZDg5YWdwbWMyNmcuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDIwOTU0NjY5NzYxNjQyNzM2OTYiLCJlbWFpbCI6InJqbTkzMDNAZ21haWwuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiJ5T2VkLUFSV01iV1BqOFVpUWhNamVBIiwibmFtZSI6Ik1vb24iLCJwaWN0dXJlIjoiaHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tL2EtL0FPaDE0R2hkQlIySm5zeTNUc3JkVTQybFRHYS1nOXhUQ0xITzRiZ3hLVlZ4PXM5Ni1jIiwiZ2l2ZW5fbmFtZSI6Ik1vb24iLCJsb2NhbGUiOiJrbyIsImlhdCI6MTY0NjM1NzIyOCwiZXhwIjoxNjQ2MzYwODI4fQ.TeHKZn7GcrDXvckir1-8GzoTPHr5BJXVYpKn-T50IwvRlaZOSagL2Yo1s8CptcaGRLY_GVOLAbzxWhViu1oD-uNDXoY6nWoEJ-ksFDXtR-JS7zz0mP3AHCaoIxUzq5_3VvB51LQdvx1E0cRv5IEeZO2rOPv_HUaXfxkKiI1M-VQTSKPOt8hfaRWS36IChg3HvgBhqrCksOO-Wpzh1CEHWR9BwB9WM9DZA77888uoN0EPGuQ_XLiDdSaiWrBRXYb6FVJo4zpvbMHbc_zdt-kEZLigHiGnck7D4MeWbpu9Z7JRDWk0eT_pvE9mAP-6mHB-vgXKoPIlSt7TRA4e_UmPeg";
   private final String accessToken = "ya29.A0ARrdaM_uBASQPOnRA9KE3_u9uADkL2HGwcKE0dsv_z6TbVKeStpzsUbckGRWniZxvVcU5wfT843Z2esWfMRatT1uGPnj9cqtvNAjCjerxlYALBMB_Ifgc-anHbzArR44zNnqU6VcB4pwfyWD4BoQCREdEy8p";
 
+  GoogleOidcVerifier googleOidcVerifier;
+
+  @BeforeEach
+  void setUp() {
+    googleOidcVerifier = new GoogleOidcVerifier(memberRepository, new MockWebClientWrapper());
+  }
+
   @Test
   @DisplayName("URL Decoder 활용")
   void decodeByString() {
-
     String[] chunks = idToken.split("\\.");
     Base64.Decoder urlDecoder = Base64.getUrlDecoder();
 
     String header = new String(urlDecoder.decode(chunks[0]));
     String payload = new String(urlDecoder.decode(chunks[1]));
 
-    System.out.println("header = " + header);
-    System.out.println("payload = " + payload);
-
-    Assertions.assertThat(header).isNotBlank();
-    Assertions.assertThat(payload).isNotBlank();
+    assertThat(header).isNotBlank();
+    assertThat(payload).isNotBlank();
   }
 
   @Test
@@ -36,18 +47,29 @@ class GoogleOidcVerifierTest {
   void decodeByJwtLibrary() {
     DecodedJWT jwt = JWT.decode(idToken);
 
-    String iss = jwt.getClaim("iss").asString();
-    String azp = jwt.getClaim("azp").asString();
-    String aud = jwt.getClaim("aud").asString();
-    String sub = jwt.getClaim("sub").asString();
-    String email = jwt.getClaim("email").asString();
-    String atHash = jwt.getClaim("at_hash").asString();
-    String name = jwt.getClaim("name").asString();
-    String picture = jwt.getClaim("picture").asString();
-    String givenName = jwt.getClaim("given_name").asString();
-    String locale = jwt.getClaim("locale").asString();
-    Date iat = jwt.getClaim("iat").asDate();
-    Date exp = jwt.getClaim("exp").asDate();
-    boolean emailVerified = jwt.getClaim("email_verified").asBoolean();
+    assertThat(jwt.getClaims()).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("구글 발행자 확인")
+  void isGoogleToken() {
+    DecodedJWT decodedJWT = JWT.decode(idToken);
+    String issuer = decodedJWT.getIssuer();
+
+    assertThat(issuer).isEqualTo("https://accounts.google.com");
+  }
+
+  @Test
+  @DisplayName("구글 발행자 확인 실패")
+  void isGoogleToken_failByWrongToken() {
+    OidcIdToken oidcIdToken = OidcIdToken
+        .withTokenValue("1")
+        .issuer(TokenConstants.OAUTH2_GOOGLE_TOKEN_ISSUER)
+        .build();
+
+    String idToken = oidcIdToken.getTokenValue();
+
+    assertThrows(TokenException.class,
+        () -> googleOidcVerifier.isGoogleToken(idToken));
   }
 }

--- a/src/test/java/com/support/oauth2postservice/security/jwt/factory/EllipticCurveFactoryTest.java
+++ b/src/test/java/com/support/oauth2postservice/security/jwt/factory/EllipticCurveFactoryTest.java
@@ -81,9 +81,10 @@ class EllipticCurveFactoryTest {
     }
 
     @Test
-    @DisplayName("Token 확인 실패 - 빈 토큰 값")
+    @DisplayName("Token 확인 false - 빈 토큰 값")
     void isValid_token_failByEmptyToken() {
-      assertThrows(TokenException.class, () -> ellipticCurveVerifier.isValid(""));
+      boolean validity = ellipticCurveVerifier.isValid("");
+      assertFalse(validity);
     }
   }
 }


### PR DESCRIPTION
- add issuer claim to elliptic-jwt
- add check origin feature in token-verifier
- restore failed test
- return unmodifiable collection when get-method is requested in oauth2-user-principal
- add pre-authorize to member-view-controller
- change environment for embedded-redis-config