### PR TITLE
feat($member-api): add leave-method in member-api

### DIFF
--- a/src/main/java/com/support/oauth2postservice/controller/api/MemberApiController.java
+++ b/src/main/java/com/support/oauth2postservice/controller/api/MemberApiController.java
@@ -2,8 +2,10 @@ package com.support.oauth2postservice.controller.api;
 
 import com.support.oauth2postservice.domain.enumeration.Role;
 import com.support.oauth2postservice.service.MemberService;
+import com.support.oauth2postservice.service.dto.request.MemberDeleteRequest;
 import com.support.oauth2postservice.service.dto.request.MemberEditRequest;
 import com.support.oauth2postservice.service.dto.request.MemberSignupRequest;
+import com.support.oauth2postservice.util.CookieUtils;
 import com.support.oauth2postservice.util.SecurityUtils;
 import com.support.oauth2postservice.util.constant.SpELConstants;
 import com.support.oauth2postservice.util.constant.UriConstants;
@@ -12,11 +14,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import java.net.URI;
 
@@ -35,7 +36,7 @@ public class MemberApiController {
     return ResponseEntity.created(uri).build();
   }
 
-  @PatchMapping(UriConstants.Mapping.EDIT_PAGE)
+  @PatchMapping(UriConstants.Mapping.MEMBERS_EDIT)
   @PreAuthorize("@checker.isAuthorized(#memberEditRequest.id)")
   public ResponseEntity<Void> edit(@RequestBody @Valid MemberEditRequest memberEditRequest) {
     Role currentUserRole = SecurityUtils.getRoleFromCurrentUser();
@@ -46,7 +47,21 @@ public class MemberApiController {
   }
 
   private void throwIfNotAuthorized(Role currentUserRole, Role toBeChangedRole) {
-    if (currentUserRole.compareTo(toBeChangedRole) < 0)
+    if (!currentUserRole.isSuperiorThan(toBeChangedRole))
       throw new AccessDeniedException(ExceptionMessages.Member.ACCESS_DENIED);
+  }
+
+  @DeleteMapping(UriConstants.Mapping.MEMBERS_EDIT)
+  @PreAuthorize("@checker.isOwner(#memberDeleteRequest.id) or " + SpELConstants.ADMIN_ONLY)
+  public ResponseEntity<Void> leave(
+      @RequestBody @Valid MemberDeleteRequest memberDeleteRequest,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+
+    Role roleFromCurrentUser = SecurityUtils.getRoleFromCurrentUser();
+    memberService.leave(roleFromCurrentUser, memberDeleteRequest);
+
+    CookieUtils.clearTokenFromBrowser(request, response);
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/support/oauth2postservice/controller/view/MemberViewController.java
+++ b/src/main/java/com/support/oauth2postservice/controller/view/MemberViewController.java
@@ -33,7 +33,7 @@ public class MemberViewController {
     return "member/list";
   }
 
-  @GetMapping(UriConstants.Mapping.MEMBERS_SINGLE)
+  @GetMapping(UriConstants.Mapping.MEMBERS_DETAIL)
   @PreAuthorize("@checker.isAuthorized(#id)")
   public String getMember(@PathVariable String id, Model model) {
     MemberReadResponse memberReadResponse = memberService.findActiveMemberById(id);
@@ -42,7 +42,7 @@ public class MemberViewController {
     return "member/my-page";
   }
 
-  @GetMapping(UriConstants.Mapping.MY_PAGE)
+  @GetMapping(UriConstants.Mapping.MEMBERS_MY_PAGE)
   @PreAuthorize(SpELConstants.ANY_ROLE_ALLOWED)
   public String myPage(Model model) {
     String id = SecurityUtils.getIdFromCurrentUser();
@@ -52,7 +52,7 @@ public class MemberViewController {
     return "member/my-page";
   }
 
-  @GetMapping(UriConstants.Mapping.EDIT_PAGE)
+  @GetMapping(UriConstants.Mapping.MEMBERS_EDIT)
   @PreAuthorize("@checker.isAuthorized(#id)")
   public String editPage(@RequestParam String id, Model model) {
     MemberReadResponse memberReadResponse = memberService.findActiveMemberById(id);

--- a/src/main/java/com/support/oauth2postservice/controller/view/OAuth2TokenViewController.java
+++ b/src/main/java/com/support/oauth2postservice/controller/view/OAuth2TokenViewController.java
@@ -41,7 +41,7 @@ public class OAuth2TokenViewController {
     CookieUtils.addOAuth2TokenToBrowser(response, oAuth2TokenResponse);
 
     OAuth2UserPrincipal principal = (OAuth2UserPrincipal) authentication.getPrincipal();
-    refreshTokenService.save(principal, oAuth2TokenResponse.getRefreshToken());
+    refreshTokenService.saveOrUpdate(principal, oAuth2TokenResponse.getRefreshToken());
 
     if (isUser(principal))
       return UriConstants.Keyword.REDIRECT + UriConstants.Mapping.ROOT;
@@ -63,6 +63,10 @@ public class OAuth2TokenViewController {
       HttpServletResponse response) {
 
     OAuth2TokenResponse renewedTokenResponse = oAuth2TokenService.renew(registrationId, refreshToken);
+
+    String oidcIdToken = renewedTokenResponse.getOidcIdToken();
+    Authentication authentication = oAuth2TokenVerifier.getAuthentication(oidcIdToken);
+    SecurityUtils.setAuthentication(authentication);
 
     CookieUtils.addOAuth2TokenToBrowser(response, renewedTokenResponse);
     return UriConstants.Keyword.REDIRECT + redirectUri;

--- a/src/main/java/com/support/oauth2postservice/domain/entity/RefreshToken.java
+++ b/src/main/java/com/support/oauth2postservice/domain/entity/RefreshToken.java
@@ -26,7 +26,6 @@ public class RefreshToken extends BaseEntity {
   @JoinColumn(name = ColumnConstants.Name.MEMBER_ID)
   private Member member;
 
-  @EqualsAndHashCode.Include
   @Column(name = ColumnConstants.Name.TOKEN_VALUE, nullable = false)
   private String tokenValue;
 
@@ -44,5 +43,9 @@ public class RefreshToken extends BaseEntity {
     this.expiredAt = expiredAt;
     this.tokenValue = tokenValue;
     this.authProvider = authProvider;
+  }
+
+  public void changeTokenValue(String tokenValue) {
+    this.tokenValue = tokenValue;
   }
 }

--- a/src/main/java/com/support/oauth2postservice/service/RefreshTokenService.java
+++ b/src/main/java/com/support/oauth2postservice/service/RefreshTokenService.java
@@ -47,16 +47,19 @@ public class RefreshTokenService {
   }
 
   @Transactional
-  public void save(OAuth2UserPrincipal principal, String tokenValue) {
+  public void saveOrUpdate(OAuth2UserPrincipal principal, String tokenValue) {
     Member member = memberRepository.findActiveByEmail(principal.getEmail())
         .orElseGet(() -> getNewlyRegisteredByPrincipal(principal));
 
-    RefreshToken refreshToken = RefreshToken.builder()
-        .member(member)
-        .tokenValue(tokenValue)
-        .expiredAt(LocalDateTime.now().plusYears(1))
-        .authProvider(member.getInitialAuthProvider())
-        .build();
+    RefreshToken refreshToken = refreshTokenRepository.findByEmail(member.getEmail())
+        .orElseGet(
+            () -> RefreshToken.builder()
+                .member(member)
+                .tokenValue(tokenValue)
+                .expiredAt(LocalDateTime.now().plusYears(1))
+                .authProvider(member.getInitialAuthProvider())
+                .build()
+        );
 
     refreshTokenRepository.save(refreshToken);
   }

--- a/src/main/java/com/support/oauth2postservice/service/dto/request/MemberDeleteRequest.java
+++ b/src/main/java/com/support/oauth2postservice/service/dto/request/MemberDeleteRequest.java
@@ -1,0 +1,26 @@
+package com.support.oauth2postservice.service.dto.request;
+
+import com.support.oauth2postservice.util.constant.ColumnConstants;
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberDeleteRequest {
+
+  @NotBlank
+  @Size(max = ColumnConstants.Length.ID)
+  private String id;
+
+  @Size(max = ColumnConstants.Length.DEFAULT_MAX)
+  private String password;
+
+  @Builder
+  public MemberDeleteRequest(String id, String password) {
+    this.id = id;
+    this.password = password;
+  }
+}

--- a/src/main/java/com/support/oauth2postservice/util/CookieUtils.java
+++ b/src/main/java/com/support/oauth2postservice/util/CookieUtils.java
@@ -59,6 +59,11 @@ public class CookieUtils {
     }
   }
 
+  public static void clearTokenFromBrowser(HttpServletRequest request, HttpServletResponse response) {
+    deleteCookie(request, response, TokenConstants.ID_TOKEN);
+    deleteCookie(request, response, TokenConstants.ACCESS_TOKEN);
+  }
+
   public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
     Cookie[] cookies = request.getCookies();
     if (cookies == null || cookies.length == 0)

--- a/src/main/java/com/support/oauth2postservice/util/constant/Times.java
+++ b/src/main/java/com/support/oauth2postservice/util/constant/Times.java
@@ -15,7 +15,7 @@ public enum Times {
   ACCESS_TOKEN_EXPIRATION_MILLIS(1000 * 60 * 30),
   REFRESH_TOKEN_EXPIRATION_MILLIS(1000 * 60 * 60 * 24 * 7),
 
-  COOKIE_EXPIRATION_SECONDS( 60 * 60 * 24 * 365);
+  COOKIE_EXPIRATION_SECONDS( 60 * 60 * 24 * 365 + 60 * 60 * 9);
 
   private final int value;
 

--- a/src/main/java/com/support/oauth2postservice/util/constant/UriConstants.java
+++ b/src/main/java/com/support/oauth2postservice/util/constant/UriConstants.java
@@ -17,9 +17,9 @@ public class UriConstants {
     public static final String LOGOUT = "/logout";
 
     public static final String MEMBERS = "/members";
-    public static final String MEMBERS_SINGLE = "/members/{id}";
-    public static final String MY_PAGE = "/members/my-page";
-    public static final String EDIT_PAGE = "/members/edit-page";
+    public static final String MEMBERS_DETAIL = "/members/{id}";
+    public static final String MEMBERS_EDIT = "/members/edit-page";
+    public static final String MEMBERS_MY_PAGE = "/members/my-page";
 
     public static final String ISSUE_GOOGLE_TOKEN = "/oauth2/google";
     public static final String ISSUE_OAUTH2_TOKEN = "/oauth2/{registrationId}";

--- a/src/main/resources/static/js/http-method.js
+++ b/src/main/resources/static/js/http-method.js
@@ -6,11 +6,11 @@
     throw new Error('jQuery 라이브러리를 호출해야 사용 가능합니다.');
   }
 
-  $.post = function(api_with_id, put_data, success, fail) {
+  $.post = function(api_url, post_data, success, fail) {
     $.ajax({
       method: 'POST',
-      url: api_with_id,
-      data: put_data,
+      url: api_url,
+      data: post_data,
       contentType: 'application/json',
     })
       .then(
@@ -22,10 +22,10 @@
   };
 
   if (!$.put) {
-    $.put = function(api_with_id, put_data, success, fail) {
+    $.put = function(api_url, put_data, success, fail) {
       $.ajax({
         method: 'PUT',
-        url: api_with_id,
+        url: api_url,
         data: put_data,
         contentType: 'application/json',
       })
@@ -40,10 +40,10 @@
 
 
   if (!$.patch) {
-    $.patch = function(api_with_id, patch_data, success, fail) {
+    $.patch = function(api_url, patch_data, success, fail) {
       $.ajax({
         method: 'PATCH',
-        url: api_with_id,
+        url: api_url,
         data: patch_data,
         contentType: 'application/json',
       })
@@ -58,10 +58,11 @@
 
 
   if (!$.delete) {
-    $.delete = function(api_with_id, success, fail) {
+    $.delete = function(api_url, delete_data, success, fail) {
       $.ajax({
         method: 'DELETE',
-        url: api_with_id,
+        url: api_url,
+        data: delete_data,
         dataType: 'json',
         contentType: 'application/json',
       })

--- a/src/main/resources/static/js/member-api.js
+++ b/src/main/resources/static/js/member-api.js
@@ -1,3 +1,15 @@
+function requestLogin() {
+  const data = {
+    email: $('#emailInput').val(),
+    password: $('#passwordInput').val(),
+  };
+  const post_data = JSON.stringify(data);
+
+  $.post('/members', post_data,
+    () => alert('성공'), () => alert('로그인 실패~~!'),
+  );
+}
+
 function requestEdit() {
   if ($('#password').val().length > 0 && $('#password').val().length < 4) {
     Swal.fire({
@@ -8,7 +20,6 @@ function requestEdit() {
     return;
   }
 
-  const api_with_id = '/members/edit-page';
   const data = {
     id: $('#id').val(),
     nickname: $('#nickname').val(),
@@ -19,7 +30,7 @@ function requestEdit() {
   const patch_data = JSON.stringify(data);
 
   $.patch(
-    api_with_id, patch_data,
+    '/members/edit-page', patch_data,
     () => {
       Swal.fire({
         icon: 'success',
@@ -28,7 +39,6 @@ function requestEdit() {
       }).then(() => {
         setTimeout(() => history.back(), 100);
       });
-
     },
     () => {
       Swal.fire({
@@ -42,21 +52,83 @@ function requestEdit() {
   );
 }
 
-function moveToEditPage(memberId) {
-  location.href = '/members/' + memberId;
+function requestDelete(delete_data, failText) {
+  $.delete(
+    '/members/edit-page', delete_data,
+    () => {
+      Swal.fire({
+        icon: 'success',
+        title: '삭제 되었습니다',
+        text: '홈페이지로 이동합니다',
+      }).then(() => {
+        setTimeout(() => moveToHomePage(), 100);
+      });
+    },
+    () => {
+      Swal.fire({
+        icon: 'error',
+        title: '삭제할 수 없습니다',
+        text: failText,
+      }).then(() => {
+        setTimeout(() => history.back(), 100);
+      });
+    },
+  );
 }
 
-function requestLogin() {
-  const api_with_id = '/members';
+async function requestDeleteByOwner() {
+  const { value: passwordValue } = await Swal.fire({
+    icon: 'warning',
+    title: '비밀번호를 입력해주세요',
+    input: 'password',
+    showCancelButton: true,
+    inputPlaceHolder: '비밀번호를 입력해주세요',
+    inputAttributes: {
+      minlength: 4,
+      maxLength: 255,
+      autocapitalize: 'off',
+      autocorrect: 'off',
+    },
+    inputValidator: (value) => {
+      return new Promise((resolve) => {
+        if (value.length < 4)
+          resolve('비밀번호는 4자 이상 입력해야 합니다');
+        else
+          resolve();
+      });
+    },
+  });
+
+  if (!passwordValue)
+    return;
 
   const data = {
-    email: $('#emailInput').val(),
-    password: $('#passwordInput').val(),
+    id: $('#id').val(),
+    password: passwordValue,
   };
+  let delete_data = JSON.stringify(data);
 
-  const patch_data = JSON.stringify(data);
+  await requestDelete(delete_data, '비밀번호가 맞지 않습니다');
+}
 
-  $.post(api_with_id, patch_data,
-    () => alert('성공'), () => alert('로그인 실패~~!'),
-  );
+async function requestDeleteByAdmin() {
+  const data = {
+    id: $('#id').val(),
+    password: null
+  };
+  const delete_data = JSON.stringify(data);
+
+  await requestDelete(delete_data, '요청 권한이 없습니다');
+}
+
+function moveToHomePage() {
+  location.href = '/';
+}
+
+function moveToDetailPage(memberId) {
+  location.href = `/members/${memberId}`;
+}
+
+function moveToEditPage(memberId) {
+  location.href = `/members/edit-page?id=${memberId}`;
 }

--- a/src/main/resources/templates/member/edit-page.html
+++ b/src/main/resources/templates/member/edit-page.html
@@ -42,7 +42,7 @@
       </div>
     </form>
     <div class='col-12 mt-4' style='text-align: center;'>
-      <button class='btn btn-primary' th:onclick='requestEdit()'>수정 요청</button>
+      <button class='btn btn-outline-primary' th:onclick='requestEdit()'>수정 하기</button>
     </div>
   </div>
   <th:block layout:fragment='customScriptFragment'>

--- a/src/main/resources/templates/member/list.html
+++ b/src/main/resources/templates/member/list.html
@@ -22,7 +22,7 @@
         <th>auth-provider</th>
       </tr>
       <tr style='cursor: pointer' th:each='member : ${memberReadResponses}'
-          th:onclick='moveToEditPage([[${member.id}]])'>
+          th:onclick='moveToDetailPage([[${member.id}]])'>
         <td th:text='${member.id}'></td>
         <td th:text='${member.email}'></td>
         <td th:text='${member.nickname}'></td>

--- a/src/main/resources/templates/member/my-page.html
+++ b/src/main/resources/templates/member/my-page.html
@@ -34,13 +34,19 @@
       </div>
     </form>
     <div class='col-12 mt-4' style='text-align: center;'>
-      <button class='btn btn-primary' th:onclick='goToEditPage([[${memberReadResponse.id}]])'>수정</button>
+      <button class='btn btn-outline-primary' th:onclick='moveToEditPage([[${memberReadResponse.id}]])'>수정</button>
+      <button class='btn btn-outline-danger'
+              th:if='${memberReadResponse.role eq "ADMIN"}'
+              th:onclick='requestDeleteByAdmin()'>삭제
+      </button>
+      <button class='btn btn-outline-danger'
+              th:if='${memberReadResponse.role ne "ADMIN" and memberReadResponse.email eq #authentication.name}'
+              th:onclick='requestDeleteByOwner()'>삭제
+      </button>
     </div>
   </div>
-  <script>
-    function goToEditPage(id) {
-      location.href = '/members/edit-page?id=' + id;
-    }
-  </script>
+  <th:block layout:fragment='customScriptFragment'>
+    <script th:src='@{/js/member-api.js}' type='text/javascript'></script>
+  </th:block>
 </th:block>
 </html>

--- a/src/test/java/com/support/oauth2postservice/domain/member/entity/MemberTest.java
+++ b/src/test/java/com/support/oauth2postservice/domain/member/entity/MemberTest.java
@@ -7,6 +7,7 @@ import com.support.oauth2postservice.domain.enumeration.Status;
 import com.support.oauth2postservice.helper.MemberTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -53,14 +54,6 @@ class MemberTest {
   }
 
   @Test
-  @DisplayName("개인정보 수정 성공")
-  void editInfo() {
-    user.changeBy("AAAA", null, null);
-
-    assertThat(user.getNickname()).isEqualTo("AAAA");
-  }
-
-  @Test
   @DisplayName("탈퇴 성공")
   void leave() {
     user.leave();
@@ -76,11 +69,32 @@ class MemberTest {
     assertThrows(IllegalStateException.class, () -> user.leave());
   }
 
-  @Test
-  @DisplayName("권한 변경 성공")
-  void changeRole() {
-    manager.changeBy(null, Role.USER, null);
+  @Nested
+  @DisplayName("개인정보 변경")
+  class editMemberInfoTest {
 
-    assertThat(manager.getRole()).isEqualTo(Role.USER);
+    @Test
+    @DisplayName("닉네임 변경 성공")
+    void editInfo() {
+      user.changeBy("AAAA", null, null);
+
+      assertThat(user.getNickname()).isEqualTo("AAAA");
+    }
+
+    @Test
+    @DisplayName("권한 변경 성공")
+    void changeRole() {
+      user.changeBy(null, Role.MANAGER, null);
+
+      assertThat(user.getRole()).isEqualTo(Role.MANAGER);
+    }
+
+    @Test
+    @DisplayName("활성 상태 변경 성공")
+    void changeStatus() {
+      user.changeBy(null, null, Status.INACTIVE);
+
+      assertThat(user.getStatus()).isEqualTo(Status.INACTIVE);
+    }
   }
 }

--- a/src/test/java/com/support/oauth2postservice/helper/MemberTestHelper.java
+++ b/src/test/java/com/support/oauth2postservice/helper/MemberTestHelper.java
@@ -1,7 +1,8 @@
 package com.support.oauth2postservice.helper;
 
-import com.support.oauth2postservice.domain.enumeration.Role;
 import com.support.oauth2postservice.domain.entity.Member;
+import com.support.oauth2postservice.domain.enumeration.Role;
+import com.support.oauth2postservice.service.dto.request.MemberDeleteRequest;
 import com.support.oauth2postservice.service.dto.request.MemberEditRequest;
 import com.support.oauth2postservice.service.dto.request.MemberSignupRequest;
 
@@ -70,6 +71,13 @@ public class MemberTestHelper {
     return MemberEditRequest.builder()
         .nickname(USER_NICKNAME_AFTER_EDIT)
         .password(PASSWORD + PASSWORD)
+        .build();
+  }
+
+  public static MemberDeleteRequest createDeleteRequest(String memberId) {
+    return MemberDeleteRequest.builder()
+        .id(memberId)
+        .password(PASSWORD)
         .build();
   }
 }

--- a/src/test/java/com/support/oauth2postservice/helper/RefreshTokenTestHelper.java
+++ b/src/test/java/com/support/oauth2postservice/helper/RefreshTokenTestHelper.java
@@ -1,0 +1,23 @@
+package com.support.oauth2postservice.helper;
+
+import com.support.oauth2postservice.domain.entity.Member;
+import com.support.oauth2postservice.domain.entity.RefreshToken;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class RefreshTokenTestHelper {
+
+  private static final String TOKEN_VALUE = UUID.randomUUID().toString();
+
+  public static RefreshToken create() {
+    Member member = MemberTestHelper.createUser();
+
+    return RefreshToken.builder()
+        .member(member)
+        .tokenValue(TOKEN_VALUE)
+        .expiredAt(LocalDateTime.now().plusYears(100))
+        .authProvider(member.getInitialAuthProvider())
+        .build();
+  }
+}

--- a/src/test/java/com/support/oauth2postservice/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/support/oauth2postservice/service/RefreshTokenServiceTest.java
@@ -1,0 +1,35 @@
+package com.support.oauth2postservice.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@Disabled
+@DisplayName("리프레시 토큰 서비스 테스트")
+class RefreshTokenServiceTest extends ServiceTest {
+
+  @BeforeEach
+  void setUp() {
+  }
+
+  @Test
+  @DisplayName("")
+  void findByEmail() {
+  }
+
+  @Test
+  @DisplayName("")
+  void findByMember() {
+  }
+
+  @Test
+  @DisplayName("")
+  void findByTokenValue() {
+  }
+
+  @Test
+  @DisplayName("")
+  void saveOrUpdate() {
+  }
+}

--- a/src/test/java/com/support/oauth2postservice/service/ServiceTest.java
+++ b/src/test/java/com/support/oauth2postservice/service/ServiceTest.java
@@ -2,6 +2,7 @@ package com.support.oauth2postservice.service;
 
 import com.support.oauth2postservice.domain.repository.MemberRepository;
 import com.support.oauth2postservice.domain.repository.PostRepository;
+import com.support.oauth2postservice.domain.repository.RefreshTokenRepository;
 import com.support.oauth2postservice.security.service.CustomUserDetailsService;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -30,4 +31,9 @@ public abstract class ServiceTest {
   protected MemberService memberService;
   @InjectMocks
   protected CustomUserDetailsService customUserDetailsService;
+
+  @Mock
+  protected RefreshTokenRepository refreshTokenRepository;
+  @InjectMocks
+  protected RefreshTokenService refreshTokenService;
 }


### PR DESCRIPTION
feat($member-api): add request-edit & delete function in js
- change button css
- rename variables in js function
- rename and relocate member-api function in js

feat($cookie): add clearing-tokens from browser method
- make cookie-expiration-time to GMT +9

refactor($token-service): refactor saving-token logic
- change save to save-or-update
- set authentication in security-context-holder at renewal

feat($member-api): add leave-method in member-api
- add member-delete-request
- renaming constants related to member
- restore failed test related to member