### PR TITLE
refactor($oauth2-token): relocate of find-or-save oauth2-user logic

### DIFF
--- a/src/main/java/com/support/oauth2postservice/controller/view/OAuth2TokenViewController.java
+++ b/src/main/java/com/support/oauth2postservice/controller/view/OAuth2TokenViewController.java
@@ -37,11 +37,11 @@ public class OAuth2TokenViewController {
     String oidcIdToken = oAuth2TokenResponse.getOidcIdToken();
 
     Authentication authentication = oAuth2TokenVerifier.getAuthentication(oidcIdToken);
-    SecurityUtils.setAuthentication(authentication);
-    CookieUtils.addOAuth2TokenToBrowser(response, oAuth2TokenResponse);
-
     OAuth2UserPrincipal principal = (OAuth2UserPrincipal) authentication.getPrincipal();
     refreshTokenService.saveOrUpdate(principal, oAuth2TokenResponse.getRefreshToken());
+
+    SecurityUtils.setAuthentication(authentication);
+    CookieUtils.addOAuth2TokenToBrowser(response, oAuth2TokenResponse);
 
     if (isUser(principal))
       return UriConstants.Keyword.REDIRECT + UriConstants.Mapping.ROOT;

--- a/src/main/java/com/support/oauth2postservice/security/dto/OAuth2UserPrincipal.java
+++ b/src/main/java/com/support/oauth2postservice/security/dto/OAuth2UserPrincipal.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.OAuth2Token;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
@@ -27,6 +26,8 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class OAuth2UserPrincipal implements OAuth2User, OidcUser {
 
+  private static final String NOT_VALID_TOKEN_VALUE = "NOT_VALID";
+
   private final String id;
   private final String email;
   private final Status status;
@@ -41,11 +42,13 @@ public class OAuth2UserPrincipal implements OAuth2User, OidcUser {
         member.getId(),
         member.getEmail(),
         member.getStatus(),
-        Jwt.withTokenValue("NOT_VALID")
+        Jwt.withTokenValue(NOT_VALID_TOKEN_VALUE)
             .header(TokenConstants.BEARER_TYPE, TokenConstants.BEARER_TYPE)
-            .issuer(TokenConstants.OAUTH2_GOOGLE_TOKEN_ISSUER)
+            .issuer(TokenConstants.GOOGLE_TOKEN_ISSUER)
             .build(),
-        OidcIdToken.withTokenValue("NOT_VALID").issuer(TokenConstants.OAUTH2_GOOGLE_TOKEN_ISSUER).build(),
+        OidcIdToken.withTokenValue(NOT_VALID_TOKEN_VALUE)
+            .issuer(TokenConstants.GOOGLE_TOKEN_ISSUER)
+            .build(),
         Collections.emptyMap(),
         Collections.emptyMap(),
         Collections.singletonList(member.getRole())
@@ -70,7 +73,9 @@ public class OAuth2UserPrincipal implements OAuth2User, OidcUser {
         member.getEmail(),
         member.getStatus(),
         oAuth2Token,
-        OidcIdToken.withTokenValue("").build(),
+        OidcIdToken.withTokenValue(NOT_VALID_TOKEN_VALUE)
+            .issuer(TokenConstants.GOOGLE_TOKEN_ISSUER)
+            .build(),
         Collections.emptyMap(),
         oAuth2User.getAttributes(),
         Collections.singletonList(member.getRole())

--- a/src/main/java/com/support/oauth2postservice/security/oauth2/OAuth2Attributes.java
+++ b/src/main/java/com/support/oauth2postservice/security/oauth2/OAuth2Attributes.java
@@ -34,7 +34,7 @@ public class OAuth2Attributes {
   }
 
   public static OAuth2Attributes of(String registrationId, Map<String, Object> attributes) {
-    return ATTRIBUTES_BY_PROVIDER.get(registrationId).apply(attributes);
+    return ATTRIBUTES_BY_PROVIDER.get(registrationId.toLowerCase()).apply(attributes);
   }
 
   private static OAuth2Attributes ofGoogleAttributes(Map<String, Object> attributes) {

--- a/src/main/java/com/support/oauth2postservice/util/constant/TokenConstants.java
+++ b/src/main/java/com/support/oauth2postservice/util/constant/TokenConstants.java
@@ -10,7 +10,7 @@ public class TokenConstants {
   public static final String AUTHORIZATION_HEADER = "Authorization";
 
   public static final String LOCAL_TOKEN_ISSUER = "https://accounts.support.com";
-  public static final String OAUTH2_GOOGLE_TOKEN_ISSUER = "https://accounts.google.com";
+  public static final String GOOGLE_TOKEN_ISSUER = "https://accounts.google.com";
 
   public static final String CODE = "code";
   public static final String ERROR = "error";
@@ -27,6 +27,7 @@ public class TokenConstants {
   public static final String ACCESS_TOKEN = "access_token";
   public static final String REFRESH_TOKEN = "refresh_token";
 
+  public static final String NAME = "name";
   public static final String EMAIL = "email";
   public static final String USER_ID = "user_id";
   public static final String AUTHORITIES = "authorities";

--- a/src/test/java/com/support/oauth2postservice/util/QueryDslUtilsTest.java
+++ b/src/test/java/com/support/oauth2postservice/util/QueryDslUtilsTest.java
@@ -1,0 +1,20 @@
+package com.support.oauth2postservice.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QueryDslUtilsTest {
+
+  @Test
+  @DisplayName("")
+  void equalsAnyIgnoreCase() {
+    String[] strings = {"panda", "bear", "yahoo"};
+
+    assertFalse(StringUtils.equalsAnyIgnoreCase("pand", strings));
+    assertTrue(StringUtils.equalsAnyIgnoreCase("panda", strings));
+  }
+}


### PR DESCRIPTION
test($oauth2-token): add test code for oidc-verifier

refactor($oauth2-token): relocate of find-or-save oauth2-user logic
- remove it at refresh-token-service
- reuse it by custom-oauth2-member-service
- change locate of finding-or-saving oauth2-user logic in token-view-controller