### PR TITLE
refactor($sort-utils): prepare for exception case

### DIFF
--- a/src/main/java/com/support/oauth2postservice/controller/view/OAuth2TokenViewController.java
+++ b/src/main/java/com/support/oauth2postservice/controller/view/OAuth2TokenViewController.java
@@ -3,6 +3,7 @@ package com.support.oauth2postservice.controller.view;
 import com.support.oauth2postservice.domain.enumeration.Role;
 import com.support.oauth2postservice.security.dto.OAuth2UserPrincipal;
 import com.support.oauth2postservice.security.jwt.OAuth2TokenVerifier;
+import com.support.oauth2postservice.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.support.oauth2postservice.security.oauth2.OAuth2TokenResponse;
 import com.support.oauth2postservice.service.OAuth2TokenService;
 import com.support.oauth2postservice.service.RefreshTokenService;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Controller
@@ -26,12 +28,16 @@ public class OAuth2TokenViewController {
   private final OAuth2TokenService oAuth2TokenService;
   private final OAuth2TokenVerifier oAuth2TokenVerifier;
   private final RefreshTokenService refreshTokenService;
+  private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
   @GetMapping(UriConstants.Mapping.ISSUE_OAUTH2_TOKEN)
   public String loginIfRefreshTokenNotExists(
       @PathVariable String registrationId,
       @RequestParam String code,
+      HttpServletRequest request,
       HttpServletResponse response) {
+
+    httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
 
     OAuth2TokenResponse oAuth2TokenResponse = oAuth2TokenService.getOAuth2Token(registrationId, code);
     String oidcIdToken = oAuth2TokenResponse.getOidcIdToken();

--- a/src/main/java/com/support/oauth2postservice/security/jwt/OAuth2TokenAuthenticationFilter.java
+++ b/src/main/java/com/support/oauth2postservice/security/jwt/OAuth2TokenAuthenticationFilter.java
@@ -16,7 +16,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/support/oauth2postservice/util/SecurityUtils.java
+++ b/src/main/java/com/support/oauth2postservice/util/SecurityUtils.java
@@ -37,7 +37,6 @@ public class SecurityUtils {
   }
 
   public static void setAuthentication(Authentication authentication) {
-    SecurityContextHolder.clearContext();
     SecurityContextHolder.getContext().setAuthentication(authentication);
   }
 }

--- a/src/main/java/com/support/oauth2postservice/util/SortUtils.java
+++ b/src/main/java/com/support/oauth2postservice/util/SortUtils.java
@@ -2,8 +2,10 @@ package com.support.oauth2postservice.util;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.bouncycastle.util.Arrays;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
@@ -14,9 +16,13 @@ import java.util.stream.IntStream;
 public class SortUtils {
 
   public static List<Pair<String, Sort.Direction>> getPairs(String[] sorts, String[] orders) {
-    return IntStream.range(0, Math.min(sorts.length, orders.length))
+    if (ArrayUtils.getLength(sorts) > ArrayUtils.getLength(orders))
+      orders = Arrays.append(orders, "");
+
+    final String[] finalOrders = orders;
+    return IntStream.range(0, sorts.length)
         .mapToObj(i -> {
-          String order = orders[i];
+          String order = finalOrders[i];
           Sort.Direction direction = Sort.Direction.DESC;
           if (StringUtils.isNotBlank(order) && StringUtils.equalsIgnoreCase(order, Sort.Direction.ASC.name()))
             direction = Sort.Direction.ASC;


### PR DESCRIPTION
refactor($sort-utils): prepare for exception case
- prepare in case of empty sorts & orders array

refactor($security-utils): remove redundant code
- doesn't need to clear context before setting authentication

refactor($oauth2-controller): add removing pre-auth-cookie feature
- add httpCookieOAuth2AuthorizationRequestRepository to remove the cookie