### PR TITLE
refactor($sort-utils): handle indexOutOfBoundException

### DIFF
--- a/src/main/java/com/support/oauth2postservice/util/SortUtils.java
+++ b/src/main/java/com/support/oauth2postservice/util/SortUtils.java
@@ -16,10 +16,7 @@ import java.util.stream.IntStream;
 public class SortUtils {
 
   public static List<Pair<String, Sort.Direction>> getPairs(String[] sorts, String[] orders) {
-    if (ArrayUtils.getLength(sorts) > ArrayUtils.getLength(orders))
-      orders = Arrays.append(orders, "");
-
-    final String[] finalOrders = orders;
+    String[] finalOrders = getOrdersIfShorterThanSorts(sorts, orders);
     return IntStream.range(0, sorts.length)
         .mapToObj(i -> {
           String order = finalOrders[i];
@@ -29,5 +26,17 @@ public class SortUtils {
           return Pair.of(sorts[i], direction);
         })
         .collect(Collectors.toList());
+  }
+
+  private static String[] getOrdersIfShorterThanSorts(String[] sorts, String[] orders) {
+    if (ArrayUtils.getLength(sorts) > ArrayUtils.getLength(orders)) {
+      int differenceOfLength = ArrayUtils.getLength(sorts) - ArrayUtils.getLength(orders);
+
+      for (int i = 0; i < differenceOfLength; i++) {
+        orders = Arrays.append(orders, "");
+      }
+    }
+
+    return orders;
   }
 }

--- a/src/main/java/com/support/oauth2postservice/util/constant/PageConstants.java
+++ b/src/main/java/com/support/oauth2postservice/util/constant/PageConstants.java
@@ -8,7 +8,7 @@ import org.springframework.data.querydsl.QSort;
 
 public class PageConstants {
 
-  public static final int DEFAULT_PAGE_SIZE = 100;
+  public static final int DEFAULT_PAGE_SIZE = 10;
   public static final int DEFAULT_PAGE_NUMBER = 0;
   public static final QSort POST_SEARCH_DEFAULT_SORT = QSort.by(new OrderSpecifier<>(Order.DESC, QPost.post.openedAt));
   public static final QSort MEMBER_SEARCH_DEFAULT_SORT = QSort.by(new OrderSpecifier<>(Order.DESC, QMember.member.createdAt));


### PR DESCRIPTION
- change default size per page as 10
- make both sorts & orders length same